### PR TITLE
Revise and add unit tests in test-pipeline-wrapper.

### DIFF
--- a/test/test-pipeline-wrapper.js
+++ b/test/test-pipeline-wrapper.js
@@ -7,6 +7,9 @@ var path = require('path');
 var Gremlin = require('../lib/gremlin');
 var GraphWrapper = require('../lib/graph-wrapper');
 
+// For reference, see the java interface:
+// https://github.com/tinkerpop/gremlin/blob/master/gremlin-java/src/main/java/com/tinkerpop/gremlin/java/GremlinFluentPipeline.java
+
 suite('pipeline-wrapper', function () {
   var gremlin;
   var java;
@@ -31,6 +34,25 @@ suite('pipeline-wrapper', function () {
         assert(!err && name === 'marko');
         done();
       });
+    });
+  });
+
+  // We test map() here early and then use it in multiple tests below to construct expected values.
+  // This makes the tests somewhat more complex, but serves the useful purpose of making the functions
+  // more understandable to programmers learning gremlin.
+  test('map()', function (done) {
+    g.V().map().toArray(function (err, verts) {
+      assert(!err);
+      var expected = [
+        { name: 'lop', lang: 'java' },
+        { age: 27, name: 'vadas' },
+        { age: 29, name: 'marko' },
+        { age: 35, name: 'peter' },
+        { name: 'ripple', lang: 'java' },
+        { age: 32, name: 'josh' }
+      ];
+      assert.deepEqual(verts, expected);
+      done();
     });
   });
 
@@ -91,7 +113,7 @@ suite('pipeline-wrapper', function () {
   test('interval(string key, object start, object end)', function (done) {
     var lower = 0.3;
     var upper = 0.9;
-    
+
     g.E()
       .interval('weight', java.newFloat(lower), java.newFloat(upper))
       .toArray(function (err, edges) {
@@ -109,8 +131,8 @@ suite('pipeline-wrapper', function () {
     g.V().bothE('knows', 'created').toArray(function (err, edges) {
       assert(!err && edges.length === 12);
       var counts = _.countBy(edges, function (e) { return e.getLabel(); });
-      assert(counts.knows === 4);
-      assert(counts.created === 8);
+      var expected = { created: 8, knows: 4 };
+      assert.deepEqual(counts, expected);
       done();
     });
   });
@@ -119,30 +141,120 @@ suite('pipeline-wrapper', function () {
     g.V().bothE(1, 'knows', 'created').toArray(function (err, edges) {
       assert(!err && edges.length === 6);
       var counts = _.countBy(edges, function (e) { return e.getLabel(); });
-      assert(counts.knows === 3);
-      assert(counts.created === 3);
+      var expected = { created: 3, knows: 3 };
+      assert.deepEqual(counts, expected);
       done();
     });
   });
 
   test('both(string... labels)', function (done) {
-    g.V().both('knows').dedup().toArray(function (err, verts) {
+    g.V().both('knows').dedup().map().toArray(function (err, verts) {
       assert(!err && verts.length === 3);
+      var expected = [ { age: 29, name: 'marko' }, { age: 27, name: 'vadas' }, { age: 32, name: 'josh' } ];
+      assert.deepEqual(verts, expected);
       done();
     });
   });
 
   test('both(int branchFactor, string... labels)', function (done) {
-    g.V().both(1, 'knows').dedup().toArray(function (err, verts) {
+    g.V().both(1, 'knows').dedup().map().toArray(function (err, verts) {
       assert(!err && verts.length === 2);
+      var expected = [ { age: 29, name: 'marko' }, { age: 27, name: 'vadas' } ];
+      assert.deepEqual(verts, expected);
       done();
     });
   });
 
   test('bothV()', function (done) {
-    g.E('id', '7').bothV().toArray(function (err, verts) {
+    g.E('id', '7').bothV().map().toArray(function (err, verts) {
       assert(!err && verts.length === 2);
+      var expected = [ { age: 29, name: 'marko' }, { age: 27, name: 'vadas' } ];
+      assert.deepEqual(verts, expected);
       done();
+    });
+  });
+
+  test('inV()', function (done) {
+    g.E('id', '7').inV().map().toArray(function (err, verts) {
+      assert(!err && verts.length === 1);
+      var expected = [ { age: 27, name: 'vadas' } ];
+      assert.deepEqual(verts, expected);
+      done();
+    });
+  });
+
+  test('inE()', function (done) {
+    g.V('name', 'lop').inE().map().toArray(function (err, edges) {
+      assert(!err && edges.length === 3);
+      done();
+    });
+  });
+
+  // PipelineWrapper.prototype.in = function () {
+  test('in()', function (done) {
+    g.V('name', 'lop').in().map().toArray(function (err, edges) {
+      assert(!err && edges.length === 3);
+      done();
+    });
+  });
+
+  test('outV()', function (done) {
+    g.E('id', '7').outV().map().toArray(function (err, verts) {
+      assert(!err && verts.length === 1);
+      var expected = [ { age: 29, name: 'marko' } ];
+      assert.deepEqual(verts, expected);
+      done();
+    });
+  });
+
+  test('outE()', function (done) {
+    g.V('name', 'josh').outE().toArray(function (err, edges) {
+      assert(!err && edges.length === 2);
+      done();
+    });
+  });
+
+  test('out()', function (done) {
+    g.V('name', 'josh').out().toArray(function (err, edges) {
+      assert(!err && edges.length === 2);
+      done();
+    });
+  });
+
+  test('id()', function (done) {
+    g.V().id().toArray(function (err, ids) {
+      assert(!err);
+      var expected = [ '3', '2', '1', '6', '5', '4' ];
+      assert.deepEqual(ids, expected);
+      g.E().id().toArray(function (err, ids) {
+        assert(!err);
+        var expected = [ '10', '7', '9', '8', '11', '12' ];
+        assert.deepEqual(ids, expected);
+        done();
+      });
+    });
+  });
+
+  test('label()', function (done) {
+    g.E().label().toArray(function (err, labels) {
+      assert(!err);
+      var expected = [ 'created', 'knows', 'created', 'knows', 'created', 'created' ];
+      assert.deepEqual(labels, expected);
+      done();
+    });
+  });
+
+  test('property()', function (done) {
+    g.V().property('name').toArray(function (err, names) {
+      assert(!err);
+      var expected = [ 'lop', 'vadas', 'marko', 'peter', 'ripple', 'josh' ];
+      assert.deepEqual(names, expected);
+      g.V().property('age').toArray(function (err, ages) {
+        assert(!err);
+        var expected = [ null, 27, 29, 35, null, 32 ];
+        assert.deepEqual(ages, expected);
+        done();
+      });
     });
   });
 
@@ -150,15 +262,6 @@ suite('pipeline-wrapper', function () {
   // PipelineWrapper.prototype.idEdge = function () {
   // PipelineWrapper.prototype.id = function () {
   // PipelineWrapper.prototype.idVertex = function () {
-  // PipelineWrapper.prototype.inE = function () {
-  // PipelineWrapper.prototype.in = function () {
-  // PipelineWrapper.prototype.inV = function () {
-  // PipelineWrapper.prototype.label = function () {
-  // PipelineWrapper.prototype.outE = function () {
-  // PipelineWrapper.prototype.out = function (){
-  // PipelineWrapper.prototype.outV = function (){
-  // PipelineWrapper.prototype.map = function () {
-  // PipelineWrapper.prototype.property = function () {
   // PipelineWrapper.prototype.step = function () {
   test('copySplit(), _(), and fairMerge()', function (done) {
     g.V().both().toArray(function (err, bothed) {
@@ -189,8 +292,10 @@ suite('pipeline-wrapper', function () {
   });
   // PipelineWrapper.prototype.except = function () {
   test('filter()', function (done) {
-    g.V().filter('{ it -> it.name == "lop" }').toArray(function (err, recs) {
+    g.V().filter('{ it -> it.name == "lop" }').map().toArray(function (err, recs) {
       assert(!err && recs.length === 1);
+      var expected = [ { name: 'lop', lang: 'java' } ];
+      assert.deepEqual(recs, expected);
       done();
     });
   });
@@ -204,6 +309,7 @@ suite('pipeline-wrapper', function () {
     var al = new gremlin.ArrayList();
     g.V().has('lang', 'java').aggregate(al).next(function (err, v) {
       assert(!err && v && al.sizeSync() === 2);
+      // al is an ArrayList<Vertex>
       done();
     });
   });


### PR DESCRIPTION
As a learning exercise as well as to benefit other users of gremlin-node,
this commit implements some of the test documented as unimplemented.

I also revised some existing tests where I felt it was worthwhile
to make the tests produce human readable expected results. This makes
the tests easier to understand by programmers learning gremlin-node.
Additionally, I want the test failures to be more actionable, in anticipation
of the fact that I may in the future do refactorings, and want a better
safety net to ensure those changes do not introduce regressions.
