### PR TITLE
Fix a bug due to Q.all() running concurrent operations in parallel.

### DIFF
--- a/lib/element-wrapper.js
+++ b/lib/element-wrapper.js
@@ -55,8 +55,20 @@ ElementWrapper.prototype.setProperty = function (key, value, callback) {
 
 ElementWrapper.prototype.setProperties = function (props, callback) {
   var self = this;
-  return Q.all(Object.keys(props).map(function (key) { return self.setProperty(key, props[key]); }))
-    .nodeify(callback);
+  // We can't simply use Q.all like this here, because TinkerGraph doesn't handle parallel concurrent operations.
+  // return Q.all(Object.keys(props).map(function (key) { return self.setProperty(key, props[key]); })).nodeify(callback);
+
+  function setProps(keys) {
+    if (keys.length === 0) {
+      return new Q();
+    }
+    var key = _.first(keys);
+    var rest = _.rest(keys);
+    return self.setProperty(key, props[key])
+      .then(function () { return setProps(rest); });
+  }
+
+  return setProps(Object.keys(props)).nodeify(callback);
 };
 
 ElementWrapper.prototype.removeProperty = function (key, callback) {

--- a/test/test-graph-wrapper.js
+++ b/test/test-graph-wrapper.js
@@ -243,10 +243,10 @@ suite('graph-wrapper', function () {
 
   test('setProperties(props) / getProperties(props) using callback API', function (done) {
     g.getVertex('1', function (err, v) {
-      var expectedProps = { 'name': 'josh', 'age': 45 };
+      var expectedProps = { 'name': 'josh', 'age': 45, 'foo': 23, 'bar': 42, 'xxx': 'yyy' };
       v.setProperties(expectedProps, function (err) {
         assert.ifError(err);
-        v.getProperties(['name', 'age'], function (err, props) {
+        v.getProperties(Object.keys(expectedProps), function (err, props) {
           assert.ifError(err);
           assert.deepEqual(props, expectedProps);
           done();
@@ -257,9 +257,9 @@ suite('graph-wrapper', function () {
 
   test('setProperties(props) / getProperties(props) using promise API', function (done) {
     g.getVertex('1', function (err, v) {
-      var expectedProps = { 'name': 'josh', 'age': 45 };
+      var expectedProps = { 'name': 'josh', 'age': 45, 'foo': 23, 'bar': 42, 'xxx': 'yyy' };
       v.setProperties(expectedProps)
-        .then(function () { return v.getProperties(['name', 'age']); }, assert.ifError)
+        .then(function () { return v.getProperties(Object.keys(expectedProps)); }, assert.ifError)
         .then(function (props) { assert.deepEqual(props, expectedProps); }, assert.ifError)
         .done(done);
     });


### PR DESCRIPTION
ElementWrapper.setProperties() must issue an async operation per (key,value)
in the properties. TinkerGraph does not support multiple concurrent
operations, so we must force the operations to be performed sequentially.
