### PR TITLE
Don't use Q.all() for removeProperties.

### DIFF
--- a/lib/element-wrapper.js
+++ b/lib/element-wrapper.js
@@ -44,6 +44,9 @@ ElementWrapper.prototype.getProperties = function (props, callback) {
         .then(function (value) { res[prop] = value; });
     }
   );
+
+  // Q.all() can be dangerous for operations that modify the database,
+  // but should be fine here since this is read-only.
   return Q.all(propPromises)
     .then(function () { return new Q(res); })
     .nodeify(callback);
@@ -62,10 +65,9 @@ ElementWrapper.prototype.setProperties = function (props, callback) {
     if (keys.length === 0) {
       return new Q();
     }
-    var key = _.first(keys);
-    var rest = _.rest(keys);
+    var key = keys.pop();
     return self.setProperty(key, props[key])
-      .then(function () { return setProps(rest); });
+      .then(function () { return setProps(keys); });
   }
 
   return setProps(Object.keys(props)).nodeify(callback);
@@ -77,8 +79,17 @@ ElementWrapper.prototype.removeProperty = function (key, callback) {
 
 ElementWrapper.prototype.removeProperties = function (props, callback) {
   var self = this;
-  return Q.all(props.map(function (key) { return self.removeProperty(key); }))
-    .nodeify(callback);
+
+  function removeProps(keys) {
+    if (keys.length === 0) {
+      return new Q();
+    }
+    var key = keys.pop();
+    return self.removeProperty(key)
+      .then(function () { return removeProps(keys); });
+  }
+
+  return removeProps(props.slice()).nodeify(callback);
 };
 
 ElementWrapper.prototype.remove = function (callback) {


### PR DESCRIPTION
I realized I should audit the code for other places where we can modify
the database using concurrent operations perfored by Q.all().
RemoveProperties was the only case.
