### PR TITLE
Change Travis configuration to use jvm/nvm test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
-language: node_js
-node_js:
-  - "0.11"
-  - "0.10"
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+env:
+  - NODE_VERSION="0.11"
+  - NODE_VERSION="0.10"
+before_install:
+  - nvm install $NODE_VERSION
+before_script:
+  - npm install
+script:
+  - npm test


### PR DESCRIPTION
Copy the test matrix configuration now used in node-java,
but testing only jvm(1.7,1.8) X nvm(0.10,0.11).
