### PR TITLE
Revert back to toJSON.

### DIFF
--- a/bin/gremlin-console
+++ b/bin/gremlin-console
@@ -7,7 +7,7 @@ var optimist = require('optimist');
 var util = require('util');
 var vm = require('vm');
 var Gremlin = require('../lib/gremlin');
-var _ = require('underscore');
+var _ = require('lodash');
 
 var argv = optimist.alias('c', 'classpath').argv;
 argv.classpath = argv.classpath || '.';
@@ -17,8 +17,8 @@ var gremlin = new Gremlin({
 });
 
 // inject a default graph
-var TinkerGraphFactory = gremlin.java.import('com.tinkerpop.blueprints.impls.tg.TinkerGraphFactory');
-var graph = TinkerGraphFactory.createTinkerGraphSync();
+var TinkerGraphFactory = gremlin.java.import('com.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory');
+var graph = TinkerGraphFactory.createClassicSync();
 var g = gremlin.wrap(graph);
 
 console.log();
@@ -40,7 +40,7 @@ function outFunc(it) {
   if (_.isObject(it) && _.isFunction(it.toJSONSync)) {
     it = it.toJSONSync();
   }
-  return '==> ' + util.inspect(it);
+  return '==> ' + util.inspect(it, {depth: 10});
 }
 
 function evalFunc(code, context, file, cb) {

--- a/lib/edge-wrapper.js
+++ b/lib/edge-wrapper.js
@@ -21,7 +21,8 @@ EdgeWrapper.prototype.setProperty = function (key, value, callback) {
   return Q.nbind(this.el.property, this.el)(key, value).nodeify(callback);
 };
 
-EdgeWrapper.prototype.toJSON = function (callback) {
+EdgeWrapper.prototype.jsonStringify = function (callback) {
+  // This method returns a json formatted string (either via a promise or a callback)
   var self = this;
   var stream = new self.gremlin.ByteArrayOutputStream();
   var builder = self.gremlin.java.callStaticMethodSync('com.tinkerpop.gremlin.structure.io.graphson.GraphSONWriter', 'build');
@@ -32,3 +33,14 @@ EdgeWrapper.prototype.toJSON = function (callback) {
     })
     .nodeify(callback);
 };
+
+EdgeWrapper.prototype.jsonStringifySync = function () {
+  // This method returns a json formatted string (synchronously)
+  var self = this;
+  var stream = new self.gremlin.ByteArrayOutputStream();
+  var builder = self.gremlin.java.callStaticMethodSync('com.tinkerpop.gremlin.structure.io.graphson.GraphSONWriter', 'build');
+  var writer = builder.createSync();
+  writer.writeEdgeSync(stream, self.unwrap());
+  return stream.toStringSync(self.gremlin.UTF8);
+};
+

--- a/lib/gremlin.js
+++ b/lib/gremlin.js
@@ -183,24 +183,44 @@ Gremlin.prototype.extractArguments = function (args) {
   };
 };
 
-Gremlin.prototype.toJSON = function (obj, callback) {
-  if (obj && obj.toJSON) {
-    return obj.toJSON().nodeify(callback);
+Gremlin.prototype.jsonStringify = function (obj, callback) {
+  // This method returns a json formatted string (either via a promise or a callback)
+  if (obj && obj.jsonStringify) {
+    return obj.jsonStringify().nodeify(callback);
   }
   else if (_.isArray(obj)) {
-    return this.arrayToJson(obj).nodeify(callback); // returns a string '[ <json>, <json>, ... ]'
+    return this.arrayJsonStringify(obj).nodeify(callback); // returns a string '[ <json>, <json>, ... ]'
   }
   else {
     return new Q(JSON.stringify(obj)).nodeify(callback);
   }
 };
 
-Gremlin.prototype.arrayToJson = function (arr, callback) {
+Gremlin.prototype.jsonStringifySync = function (obj) {
+  // This method returns a json formatted string (synchronously)
+  if (obj && obj.jsonStringifySync) {
+    return obj.jsonStringifySync();
+  }
+  else if (_.isArray(obj)) {
+    return this.arrayJsonStringifySync(obj); // returns a string '[ <json>, <json>, ... ]'
+  }
+  else {
+    return new Q(JSON.stringify(obj));
+  }
+};
+
+Gremlin.prototype.arrayJsonStringify = function (arr, callback) {
   var self = this;
-  var promises = _.map(arr, function (val) { return self.toJSON(val); });
+  var promises = _.map(arr, function (val) { return self.jsonStringify(val); });
   return Q.all(promises)
     .then(function (results) { return '[' + results.join() + ']'; })
     .nodeify(callback);
+};
+
+Gremlin.prototype.arrayJsonStringifySync = function (arr) {
+  var self = this;
+  var results = _.map(arr, function (val) { return self.jsonStringifySync(val); });
+  return '[' + results.join() + ']';
 };
 
 Gremlin.prototype.normalizeObj = function (obj) {
@@ -228,9 +248,9 @@ Gremlin.prototype.normalizeObj = function (obj) {
   }
 };
 
-Gremlin.prototype.toJsObj = function (obj, callback) {
+Gremlin.prototype.toJSON = function (obj, callback) {
   var self = this;
-  return self.toJSON(obj)
+  return self.jsonStringify(obj)
     .then(function (jsonStr) {
       if (_.isUndefined(jsonStr))
         return undefined;
@@ -244,4 +264,19 @@ Gremlin.prototype.toJsObj = function (obj, callback) {
       }
     })
     .nodeify(callback);
+};
+
+Gremlin.prototype.toJSONSync = function (obj, callback) {
+  var self = this;
+  var jsonStr = self.jsonStringifySync(obj);
+  if (_.isUndefined(jsonStr))
+    return undefined;
+  try {
+    return self.normalizeObj(JSON.parse(jsonStr));
+  }
+  catch (err) {
+    console.error('While parsing:', obj, jsonStr);
+    console.error('Got error:', err);
+    return undefined;
+  }
 };

--- a/lib/pipeline-wrapper.js
+++ b/lib/pipeline-wrapper.js
@@ -489,7 +489,7 @@ PipelineWrapper.prototype.start = function (obj) {
 function pipePromiseWrap(op) {
   return function () {
     var argPair = this.gremlin.extractArguments(Array.prototype.slice.call(arguments));
-    dlog('pipePromiseWrap(%s)', op, argPair, this.traversal[op]);
+    dlog('pipePromiseWrap(%s)', op, argPair);
     return Q.npost(this.traversal, op, argPair.args).nodeify(argPair.callback);
   };
 }
@@ -537,34 +537,36 @@ PipelineWrapper.prototype.toArray = function (callback) {
         var it = list.getSync(i);
         arr.push(self._jsify(it));
       }
-      dlog('PipelineWrapper.prototype.toArray:', arr);
+      dlog('PipelineWrapper.prototype.toArray:', arr.length, arr);
       return arr;
     })
     .nodeify(callback);
 };
 
-// PipelineWrapper.prototype.toJSON = function (callback) {
-//   return Q.nbind(this.gremlin.toJSON, this.gremlin)(this.traversal).nodeify(callback);
-// };
-
+PipelineWrapper.prototype.toArraySync = function () {
+  var self = this;
+  var list = self.traversal.toListSync();
+  var arr = [];
+  for (var i = 0, l = list.sizeSync(); i < l; i++) {
+    var it = list.getSync(i);
+    arr.push(self._jsify(it));
+  }
+  dlog('PipelineWrapper.prototype.toArraySync:', arr.length, arr);
+  return arr;
+};
 
 PipelineWrapper.prototype.toJSON = function (callback) {
   var self = this;
-  var stream = new self.gremlin.ByteArrayOutputStream();
-  var builder = self.gremlin.java.callStaticMethodSync('com.tinkerpop.gremlin.structure.io.graphson.GraphSONWriter', 'build');
-  var writer = builder.createSync();
-  return Q.nbind(writer.writeVertices, writer)(stream, self.traversal)
-    .then(function () {
-      return Q.nbind(stream.toString, stream)(self.gremlin.UTF8);
-    })
-    .then(function (jsonString) {
-      return JSON.parse('[' + jsonString + ']');
+  self.toArray()
+    .then(function (arr) {
+      dlog('PipelineWrapper.prototype.toJSON:', arr);
+      return self.gremlin.toJSON(arr);
     })
     .nodeify(callback);
 };
 
-
-
 PipelineWrapper.prototype.toJSONSync = function () {
-  return this.gremlin.toJSONSync(this.traversal);
+  var self = this;
+  var arr = self.toArraySync();
+  return self.gremlin.toJSONSync(arr);
 };

--- a/lib/vertex-wrapper.js
+++ b/lib/vertex-wrapper.js
@@ -55,7 +55,8 @@ VertexWrapper.prototype.setProperty = function (key, value, callback) {
   return Q.nbind(this.el.singleProperty, this.el)(key, value, this.gremlin.emptyArrayList).nodeify(callback);
 };
 
-VertexWrapper.prototype.toJSON = function (callback) {
+VertexWrapper.prototype.jsonStringify = function (callback) {
+  // This method returns a json formatted string (either via a promise or a callback)
   var self = this;
   var stream = new self.gremlin.ByteArrayOutputStream();
   var builder = self.gremlin.java.callStaticMethodSync('com.tinkerpop.gremlin.structure.io.graphson.GraphSONWriter', 'build');
@@ -66,3 +67,14 @@ VertexWrapper.prototype.toJSON = function (callback) {
     })
     .nodeify(callback);
 };
+
+VertexWrapper.prototype.jsonStringifySync = function () {
+  // This method returns a json formatted string (synchronously)
+  var self = this;
+  var stream = new self.gremlin.ByteArrayOutputStream();
+  var builder = self.gremlin.java.callStaticMethodSync('com.tinkerpop.gremlin.structure.io.graphson.GraphSONWriter', 'build');
+  var writer = builder.createSync();
+  writer.writeVertexSync(stream, self.unwrap());
+  return stream.toStringSync(self.gremlin.UTF8);
+};
+

--- a/test/test-graph-wrapper.js
+++ b/test/test-graph-wrapper.js
@@ -192,7 +192,6 @@ suite('graph-wrapper', function () {
       assert.strictEqual(e.getLabel(), 'knows');
       e.value('weight')
         .then(function (weight) {
-          console.log('Edge(7) weight is:', weight);
           assert(weight > 0.0 && weight < 1.0);
         }, assert.ifError)
         .done(done);

--- a/test/test-gremlin.js
+++ b/test/test-gremlin.js
@@ -21,10 +21,10 @@ suite('gremlin', function () {
     g = new GraphWrapper(gremlin, graph);
   });
 
-  test('Wrapped objects can be converted to JS objects using gremlin.toJsObj', function (done) {
+  test('Wrapped objects can be converted to JS objects using gremlin.toJSON', function (done) {
     g.v(2, function (err, res) {
       assert.ifError(err);
-      gremlin.toJsObj(res, function (err, json) {
+      gremlin.toJSON(res, function (err, json) {
         assert.ifError(err);
         // console.log(require('util').inspect(json, {depth: null}));
         assert(json.id === 2);
@@ -33,16 +33,25 @@ suite('gremlin', function () {
     });
   });
 
-  test('gremlin.toJsObj returns null when passed null', function (done) {
-    gremlin.toJsObj(null, function (err, json) {
+  test('Wrapped objects can be converted to JS objects using gremlin.toJSONSync', function (done) {
+    g.v(2, function (err, res) {
+      assert.ifError(err);
+      var json = gremlin.toJSONSync(res);
+      assert(json.id === 2);
+      done();
+    });
+  });
+
+  test('gremlin.toJSON returns null when passed null', function (done) {
+    gremlin.toJSON(null, function (err, json) {
       assert.ifError(err);
       assert.strictEqual(json, null);
       done();
     });
   });
 
-  test('gremlin.toJSON throws error but does not crash when passed undefined', function (done) {
-    gremlin.toJsObj(undefined, function (err, json) {
+  test('gremlin.toJSON returns undefined when passed undefined', function (done) {
+    gremlin.toJSON(undefined, function (err, json) {
       assert.ifError(err);
       assert.strictEqual(json, undefined);
       done();

--- a/test/test-pipeline-wrapper.js
+++ b/test/test-pipeline-wrapper.js
@@ -88,9 +88,9 @@ suite('pipeline-wrapper', function () {
       assert.ifError(err);
       assert.ok(v instanceof VertexWrapper);
 
-      gremlin.toJsObj(v, function (err, jsonObj) {
+      gremlin.toJSON(v, function (err, jsonObj) {
         assert.ifError(err);
-        // console.log(require('util').inspect(jsonObj, {depth: null}));
+//         console.log(require('util').inspect(jsonObj, {depth: null}));
         var expected = {
           id: 1,
           label: 'vertex',
@@ -101,11 +101,66 @@ suite('pipeline-wrapper', function () {
             age: [ { id: 1, label: 'age', value: 29 } ]
           }
         };
-
         assert.deepEqual(jsonObj, expected);
         done();
       });
     });
+  });
+
+  test('V().has("lang").toJSON', function (done) {
+    g.V().has('lang').toJSON(function (err, jsonObj) {
+      assert.ifError(err);
+//       console.log(require('util').inspect(jsonObj, {depth: null}));
+      var expected = [
+        {
+          id: 3,
+          label: 'vertex',
+          type: 'vertex',
+          properties: {
+            name: [ { id: 4, label: 'name', value: 'lop' } ],
+            lang: [ { id: 5, label: 'lang', value: 'java' } ]
+          }
+        },
+        {
+          id: 5,
+          label: 'vertex',
+          type: 'vertex',
+          properties: {
+            name: [ { id: 8, label: 'name', value: 'ripple' } ],
+            lang: [ { id: 9, label: 'lang', value: 'java' } ]
+          }
+        }
+      ];
+      assert.deepEqual(jsonObj, expected);
+      done();
+    });
+  });
+
+  test('V().has("lang").toJSONSync', function (done) {
+    var jsonObj = g.V().has('lang').toJSONSync();
+//       console.log(require('util').inspect(jsonObj, {depth: null}));
+    var expected = [
+      {
+        id: 3,
+        label: 'vertex',
+        type: 'vertex',
+        properties: {
+          name: [ { id: 4, label: 'name', value: 'lop' } ],
+          lang: [ { id: 5, label: 'lang', value: 'java' } ]
+        }
+      },
+      {
+        id: 5,
+        label: 'vertex',
+        type: 'vertex',
+        properties: {
+          name: [ { id: 8, label: 'name', value: 'ripple' } ],
+          lang: [ { id: 9, label: 'lang', value: 'java' } ]
+        }
+      }
+    ];
+    assert.deepEqual(jsonObj, expected);
+    done();
   });
 
   test('V().has(key, value)', function (done) {
@@ -150,14 +205,14 @@ suite('pipeline-wrapper', function () {
     });
   });
 
-  test('g.V().toArray() -> toJsObj()', function (done) {
+  test('g.V().toArray() -> toJSON()', function (done) {
     var traversal = g.V();
     assert.ok(traversal instanceof PipelineWrapper);
 
     traversal.toArray(function (err, arr) {
       assert.ifError(err);
 
-      gremlin.toJsObj(arr, function (err, verts) {
+      gremlin.toJSON(arr, function (err, verts) {
         // console.log(require('util').inspect(verts, {depth: null}));
         var expected = [
           { id: 1,
@@ -235,12 +290,12 @@ suite('pipeline-wrapper', function () {
     });
   });
 
-  test('g.E().toArray() -> toJsObj', function (done) {
+  test('g.E().toArray() -> toJSON', function (done) {
     var traversal = g.E();
     assert.ok(traversal instanceof PipelineWrapper);
 
     traversal.toArray()
-      .then(gremlin.toJsObj.bind(gremlin), assert.ifError)
+      .then(gremlin.toJSON.bind(gremlin), assert.ifError)
       .then(function (edges) {
         assert.ok(_.isArray(edges));
         // console.log(require('util').inspect(edges, {depth: null}));
@@ -301,7 +356,7 @@ suite('pipeline-wrapper', function () {
 
   test('g.E().has(key, val)', function (done) {
     g.E().has(gremlin.T.id, 7).toArray()
-      .then(function (arr) { return gremlin.toJsObj(arr); }, assert.ifError)
+      .then(function (arr) { return gremlin.toJSON(arr); }, assert.ifError)
       .then(function (edges) {
         assert.strictEqual(edges.length, 1);
         // console.log(require('util').inspect(edges, {depth: null}));
@@ -595,7 +650,7 @@ suite('pipeline-wrapper', function () {
       assert.strictEqual(recs.length, 1);
       var v = recs[0];
       assert.ok(v instanceof VertexWrapper);
-      gremlin.toJsObj(v, function (err, jsonObj) {
+      gremlin.toJSON(v, function (err, jsonObj) {
         var expected = {
           id: 3,
           label: 'vertex',


### PR DESCRIPTION
While converting to TinkerPop3 I needed to refactor how we convert elements (vertices and edges) to JSON.
In the process I introduced a new method toJsObj, but it should have just been a new implementation
for toJSON. This commit fixes that, and provides sync and async versions.

Also changed bin/gremlin-console, enough to verify that we can at least now execute simple
queries such as 'g.V()' and 'g.E()'.
