### PR TITLE
[Delivers #88001808] Stabilize the result of propertiesToVarArgs

### DIFF
--- a/lib/gremlin.js
+++ b/lib/gremlin.js
@@ -208,7 +208,7 @@ Gremlin.prototype.extractArguments = function (args) {
 Gremlin.prototype.propertiesToVarArgs = function (props, type) {
   props = props || {};
   type = type || 'java.lang.Object';
-  return this.java.newArray(type, _.flatten(_.pairs(props)));
+  return this.java.newArray(type, _.flatten(_.sortBy(_.pairs(props), function (x) { return x[0]; })));
 };
 
 // Applies *process* to each item returned by the *javaIterator*.

--- a/test/test-gremlin.js
+++ b/test/test-gremlin.js
@@ -88,4 +88,12 @@ suite('gremlin', function () {
     assert.equal(lambda.applySync('0, 99, 100'), 'true, true, false');
   });
 
+  test('propertiesToVarArgs', function () {
+    var properties = { foo: 123, bar: 456, baz: 'one', quux: 'two' };
+    var actual = gremlin.propertiesToVarArgs(properties);
+    var expected = gremlin.java.newArray('java.lang.Object', ['bar', 456, 'baz', 'one', 'foo', 123, 'quux', 'two']);
+    var Arrays = gremlin.java.import('java.util.Arrays');
+    assert.equal(Arrays.equalsSync(actual, expected), true, Arrays.toStringSync(actual));
+  });
+
 });


### PR DESCRIPTION
In turn, this will stabilize the properties ID's resulting from various element factory methods:
- GraphWrapper.addVertex
- TraversalWrapper.addInE
- TraversalWrapper.addOutE
- TraversalWrapper.addBothE
- TraversalWrapper.addE
- VertexWrapper.addEdge